### PR TITLE
Minor fixes and changes, update README to point to quay.io docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM cucloudcollab/xvfb-firefox
 
-LABEL maintainer="Dom DePasquale dad264@psu.edu"
+LABEL maintainer="Dom DePasquale <dad264@psu.edu>, Andy Cobaugh <atc135@psu.edu>"
 
-RUN apt-get update && apt-get install --no-install-recommends -y \
-  zlib1g-dev \
-  ruby \
-  ruby-dev && \
-  rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+  apt-get upgrade --no-install-recommends -y && \
+  apt-get install --no-install-recommends -y \
+    zlib1g-dev \
+    ruby \
+    ruby-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN gem install selenium-webdriver \
   aws-sdk \

--- a/README.md
+++ b/README.md
@@ -1,22 +1,19 @@
 # samlapi
 
+[![Docker Repository on Quay](https://quay.io/repository/pennstate/aws-saml-login/status "Docker Repository on Quay")](https://quay.io/repository/pennstate/aws-saml-login)
+
 ## Usage
 
 You can use PSU WebAccess login for both API and CLI access to AWS.  
-I've tested this lightly so far by building the docker image locally, then running.
-
-I ran it by running the following command in the root of this repository:
 
 ```bash
-docker run -it --rm -v ~/.aws:/root/.aws $(docker build -q .)
+docker run -it --rm -v ~/.aws:/root/.aws quay.io/pennstate/aws-saml-login
 ```
-
-AFAIK, we don't have a PSU docker image repository for me to publish this. For now, it'll remain as source only.
 
 After this command has been run it will prompt you for your accessID and password.  This will be used to login you into PSU WebAccess. You will get a push from DUO.  Once you have confirmed the DUO notification, you will be prompted to select the role you wish to use for login, if you have only one role it will choose that automatically.  The credentials will be placed in the default credential file (~/.aws/credentials) and can be used as follows:
 
 ```bash
-aws --profile saml s3 ls
+aws --profile saml <subcommand>
 ```
 
 ## Credit & More Info

--- a/bin/samlapi.rb
+++ b/bin/samlapi.rb
@@ -131,4 +131,9 @@ puts 'Your new access key pair has been stored in the AWS configuration file und
 puts "Note that it will expire at #{token.credentials.expiration}."
 puts 'After this time you may safely rerun this script to refresh your access key pair.'
 puts 'To use this credential call the AWS CLI with the --profile option (e.g. aws --profile saml ec2 describe-instances).'
+puts 
+puts 'Optionall, simply copy/paste the following into the shell in which you wish to access AWS via the chosen role:'
+puts "export AWS_ACCESS_KEY_ID=\"#{token.credentials.access_key_id}\""
+puts "export AWS_SECRET_ACCESS_KEY=\"#{token.credentials.secret_access_key}\""
+puts "export AWS_SESSION_TOKEN=\"#{token.credentials.session_token}\""
 puts "----------------------------------------------------------------\n\n"

--- a/bin/samlapi.rb
+++ b/bin/samlapi.rb
@@ -91,6 +91,7 @@ else
   role_arn = aws_roles[0][:role_arn]
 end
 
+
 sts = Aws::STS::Client.new(region: 'us-east-1')
 token = sts.assume_role_with_saml(role_arn: role_arn,
                                   principal_arn: principal_arn,
@@ -98,7 +99,13 @@ token = sts.assume_role_with_saml(role_arn: role_arn,
 
 # Write the AWS STS token into the AWS credential file
 filename = Dir.home + AWS_CONFIG_FILE
-# puts filename
+
+if not File.file?(filename)
+  puts "Creating #{filename}"
+  File.open(filename, "w") {}
+else
+  puts "Reading #{filename}"
+end
 
 # Read in the existing config file
 config = ParseConfig.new(filename)
@@ -110,6 +117,8 @@ config.add_to_group('saml', 'region', REGION)
 config.add_to_group('saml', 'aws_access_key_id', token.credentials.access_key_id)
 config.add_to_group('saml', 'aws_secret_access_key', token.credentials.secret_access_key)
 config.add_to_group('saml', 'aws_session_token', token.credentials.session_token)
+
+puts "Writing #{filename}"
 
 # Write the updated config file
 file = File.open(filename, 'w')


### PR DESCRIPTION
* Add quay.io badge to readme and update usage section
* Handle non-existent ~/.aws/credentials file
* Output `export foo=bar` env vars for credentials instead of making the user depend on aws profiles
* Run apt-get upgrade in docker build